### PR TITLE
Show the HomePage component when home has a query

### DIFF
--- a/packages/frontity-chakra-theme/src/components/archive/archive.js
+++ b/packages/frontity-chakra-theme/src/components/archive/archive.js
@@ -10,8 +10,7 @@ const Archive = ({ state }) => {
   // Get the data of the current list.
   const data = state.source.get(state.router.link);
 
-  const isHomePage = state.router.link === "/";
-  if (isHomePage) return <HomepageArchive />;
+  if (data.isHome) return <HomepageArchive />;
 
   return (
     <Box bg="accent.50" as="section">


### PR DESCRIPTION
Right now, URLs with queries, like for example `/?some=query` won't load the HomePage component because it is hardcoded to `/`.  To solve it, I have switched to `data.isHome`.